### PR TITLE
Remove UFS reference from Wifi checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Updates and announcements are sent to the Mailing List.  Sign-up [HERE](https://
 - [x] Touchpad
 - [x] Touchscreen
 - [x] On-board Storage (UFS based)
-- [ ] WiFi (UFS based)
+- [ ] WiFi
 - [ ] Bluetooth
 - [ ] LTE
 - [ ] Accelerated Graphics


### PR DESCRIPTION
This is a bit-size fix in README, seems like somebody copy-pasted string from On-board Storage.