### PR TITLE
Clarify Ubuntu LTS Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This project provides the user/owner some options to install Linux on these devi
 
 ### Use an existing pre-built image
 
-Only the latest Ubuntu LTS (currently Bionic) pre-built images are currently available.
+The only Ubuntu LTS pre-built image currently available is Ubuntu 18.04 (Bionic).
 
 Download [THIS IMAGE](http://releases.linaro.org/aarch64-laptops/images/ubuntu/18.04/aarch64-laptops-bionic-prebuilt.img.xz) and head to the [Flashing the image](#Flashing-the-image) then [Booting into Ubuntu](#Booting-into-Ubuntu) sections below.
 


### PR DESCRIPTION
README currently implies Ubuntu 18.04 LTS is the latest Ubuntu LTS. There have since been two LTS since 18.04, they are just not available. There are also two non-LTS releases, but both of which have reached EOL and are not worth mentioning. This change clarifies the latest Ubuntu LTS available pre-built is 18.04.