### PR TITLE
Pass arguments to quick-start.sh symlink through to main script

### DIFF
--- a/quick-start.sh
+++ b/quick-start.sh
@@ -1,1 +1,1 @@
-scripts/quick-start.sh
+scripts/quick-start.sh "$@"


### PR DESCRIPTION
This addresses an issue where if the user calls `quick-start.sh` in the parent folder, no arguments appear to work, which is frustrating. This will pass those arguments along to `quick-start.sh` in the `/scripts/` folder. This is of particular importance because `quick-start.sh` is meant to be run from the parent folder: `./quick-start.sh should be executed from this project's root directory`